### PR TITLE
aggregate on request name

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
   const baseUrl = url.parse(req.url).path;
 
   let histoName = req.name ?
-        `${baseUrl} (${req.name})` :
+        `${req.name}` :
         `${baseUrl}`;
   let counterName = histoName;
 


### PR DESCRIPTION
10 requests to GET users/{{userId}} with different userId will give 10 different min, p95, avg etc. This is useful for comparing times between different users. However one might also be interested of the min, p95, avg etc for all 10 requests.

This small change will give the option to aggregate metrics based on request name (if specified). Currently, when the path contains path parameters or query strings the metrics are calculated based on unique path, even when a request name is specified.


 