### PR TITLE
Resolved param issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function MetricsByEndpoint(script, events) {
     script.config.processor = {};
   }
 
-  useOnlyRequestNames = script.config.plugins["metrics-by-endpoint-test"].useOnlyRequestNames || false;
+  useOnlyRequestNames = script.config.plugins["metrics-by-endpoint"].useOnlyRequestNames || false;
 
   script.config.processor.metricsByEndpoint_beforeRequest = metricsByEndpoint_beforeRequest;
 script.config.processor.metricsByEndpoint_afterResponse = metricsByEndpoint_afterResponse;


### PR DESCRIPTION
A typo in the plugin name caused it to look in the wrong place for the param.