### PR TITLE
Fix plugin name when reading config

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function MetricsByEndpoint(script, events) {
     script.config.processor = {};
   }
 
-  useOnlyRequestNames = script.config.plugins["metrics-by-endpoint-test"].useOnlyRequestNames || false;
+  useOnlyRequestNames = script.config.plugins["metrics-by-endpoint"].useOnlyRequestNames || false;
 
   script.config.processor.metricsByEndpoint_beforeRequest = metricsByEndpoint_beforeRequest;
 script.config.processor.metricsByEndpoint_afterResponse = metricsByEndpoint_afterResponse;


### PR DESCRIPTION
Fixes useOnlyRequestNames property not being found because config is looking for metrics-by-endpoint**-test** instead of metrics-by-endpoint which produced the error `WARNING: Could not initialize plugin metrics-by-endpoint (Cannot read property 'useOnlyRequestNames' of undefined)`