### PR TITLE
feat: introduce metrics namespace for naming compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ scenarios:
         count: 100
 ```
 
+In order to ensure the latency metrics by [artillery-plugin-ensure](https://github.com/artilleryio/artillery-plugin-ensure) you have to specify a custom namespace for the latency metrics like this:
+
+```yaml
+config:
+  target: "https://my-app.acme-corp.internal"
+  plugins:
+    metrics-by-endpoint:
+      useOnlyRequestNames: true
+      metricsNamespace: "latency_metrics"
+    ensure: {}
+  ensure:
+    thresholds:
+      - "latency_metrics.response_time.orders.p95": 150
+scenarios:
+  - flow:
+      - loop:
+          - get:
+              url: "/foos/{{ $loopElement }}"
+              name: "orders"
+        count: 100
+```
+
+This is due to different naming patterns for metrics in both plugins.
+
 # License
 
 MPL 2.0

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = { Plugin: MetricsByEndpoint };
 const debug = require('debug')('plugin:metrics-by-endpoint');
 
 let useOnlyRequestNames;
+let metricsPrefix;
 
 // NOTE: Will not work with `parallel` - need request UIDs for that
 function MetricsByEndpoint(script, events) {
@@ -30,6 +31,7 @@ function MetricsByEndpoint(script, events) {
   }
 
   useOnlyRequestNames = script.config.plugins['metrics-by-endpoint'].useOnlyRequestNames || false;
+  metricsPrefix = script.config.plugins['metrics-by-endpoint'].metricsNamespace || 'plugins.metrics-by-endpoint';
 
   script.config.processor.metricsByEndpoint_afterResponse = metricsByEndpoint_afterResponse;
 
@@ -52,14 +54,14 @@ function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
     reqName += baseUrl;
   }
 
-  const histoName = `plugins.metrics-by-endpoint.response_time.${reqName}`;
+  const histoName = `${metricsPrefix}.response_time.${reqName}`;
 
   if (res.headers['server-timing']) {
     const timing = getServerTimingTotal(res.headers['server-timing']);
-    events.emit('histogram', `plugins.metrics-by-endpoint.server-timing.${reqName}`, timing);
+    events.emit('histogram', `${metricsPrefix}.server-timing.${reqName}`, timing);
   }
 
-  events.emit('counter', `plugins.metrics-by-endpoint.${reqName}.codes.${res.statusCode}`, 1);
+  events.emit('counter', `${metricsPrefix}.${reqName}.codes.${res.statusCode}`, 1);
   events.emit('histogram', histoName, res.timings.phases.firstByte);
   return done();
 }


### PR DESCRIPTION
This addresses the current naming incompatibility between metrics created with `plugins.metrics-by-endpoint` prefix and the expected naming pattern of metrics in the ensure plugin (`-` vs. `_`).